### PR TITLE
Add m2ee-api.jar to project dependencies

### DIFF
--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/MendixGradlePlugin.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/MendixGradlePlugin.kt
@@ -98,6 +98,7 @@ class MendixGradlePlugin: Plugin<Project> {
             val mendixLibs = arrayOf(
                 "com.mendix.json.jar",
                 "com.mendix.logging-api.jar",
+                "com.mendix.m2ee-api.jar",
                 "com.mendix.public-api.jar",
                 "org.eclipse.jetty.toolchain.jetty-servlet-api.jar",
                 "org.eclipse.jetty.toolchain.jetty-javax-websocket-api.jar")


### PR DESCRIPTION
Another JAR is needed as compile dependency. Adding m2ee-api.jar to the list.