### PR TITLE
Fix installation detection for runtime

### DIFF
--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/ToolFinder.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/ToolFinder.kt
@@ -100,7 +100,7 @@ class PathToolFinder(val paths: List<File>, val logger: Logger, val fallback: To
     override fun isRuntimeInstalled(): Boolean {
         logger.debug("Searching for runtime (${paths.size})")
         return paths
-            .map { e -> File(e, "runtime") }
+            .map { e -> File(e, "runtime/launcher") }
             .filter { e -> logger.debug("checking runtime dir: {}", e); e.exists() }.isNotEmpty() || fallback.isModelerInstalled();
     }
 


### PR DESCRIPTION
The runtime installation detection should check for a more specific folder as the modeler distribution also contains a runtime folder. Updated the installation check to search for the launcher folder instead.