### PR TITLE
Improve mxRun with specific arguments

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -215,8 +215,11 @@ Parameters: None
 
 ## `mxRun`
 
-Runs the application using the generated configuration file and unzipped MDA. This is an implementation of the Gradle
-`JavaExec` task. It assumes `mxbuild` is executed.
+Runs the application using the generated configuration file and unzipped MDA. This is an extension of the
+JavaExec task. Parameters are preconfigured with default to run the app with default configuration. The 
+task is extended with a `configFile` parameter for easy use.  
+
+**NOTE**: Don't use the `args` parameter. The value is set automatically.
 
 Execute:
 
@@ -226,11 +229,13 @@ gradlew.bat mxRun
 
 Parameters: See [JavaExec](https://docs.gradle.org/8.5/dsl/org.gradle.api.tasks.JavaExec.html)
 
-| Parameter   | Type    | Description                                                                  |
-|-------------|---------|------------------------------------------------------------------------------|
-| `classpath` | String  | Set to `runtimelauncher.jar` from the Runtime distribution.                  |
-| `jvmArgs`   | String | Defines JVM arguments. Needs to have `MX_INSTALL_PATH` at minimal.           |
-| `args`      | String | Passed the MDA deployment folder and config file. Defaults to Defaults.conf. |
+| Parameter   | Type    | Description                                                                                   |
+|-------------|---------|-----------------------------------------------------------------------------------------------|
+| `appFolder`| Directory | The directory where the compiled app is stored.        |
+| `configFile` | File  | The configuration file to use. Defaults to `Default.conf` as generated from the source. |
+| `classpath` | String  | Set to `runtimelauncher.jar` from the Runtime distribution.                                   |
+| `jvmArgs`   | String | Defines JVM arguments. Needs to have `MX_INSTALL_PATH` at minimal.                            |
+| `args`      | String | Content is set based on config options `appFolder` and `configFile`. Don't use this argument. |
 
 
 ## `mxStartScripts`

--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/MendixGradlePlugin.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/MendixGradlePlugin.kt
@@ -258,7 +258,7 @@ class MendixGradlePlugin: Plugin<Project> {
             }
         }
 
-        project.tasks.register<JavaExec>("mxRun", JavaExec::class.java) { task ->
+        project.tasks.register<MxRun>("mxRun", MxRun::class.java) { task ->
             task.group = PLUGIN_GROUP_MX
             task.description = "Run the Mendix project"
 
@@ -269,22 +269,18 @@ class MendixGradlePlugin: Plugin<Project> {
                     .withMendixVersion(e)
                     .withProject(project)
                     .build()
-                "${toolFinder.getRuntimeLocation()}/launcher/runtimelauncher.jar"
+                "${toolFinder.getRuntimeLocation()}${File.separator}launcher${File.separator}runtimelauncher.jar"
             }.get())
             task.jvmArgs(extension.mendixVersion.map { e ->
                 val toolFinder = ToolFinderBuilder()
                     .withMendixVersion(e)
                     .withProject(project)
                     .build()
-                listOf("-DMX_INSTALL_PATH=${toolFinder.getRuntimeLocation()}/..")
+                listOf("-DMX_INSTALL_PATH=${toolFinder.getRuntimeLocation()}${File.separator}..")
             }.get())
 
-            val args = listOf(
-                project.tasks.getByName("mxDeployMda").outputs.files.singleFile.absolutePath,
-                project.layout.buildDirectory.file(appBuildDir + "/Default.conf").get().asFile.absolutePath
-            )
-            task.args(args)
-
+            task.appFolder.set(project.tasks.getByName("mxDeployMda").outputs.files.singleFile)
+            task.configFile.set(project.layout.buildDirectory.file("${appBuildDir}${File.separator}Default.conf"))
         }
 
         // -------------------------------------------------------------------------------------------------------------

--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/tasks/MxRun.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/tasks/MxRun.kt
@@ -1,0 +1,36 @@
+package mendixlabs.mendixgradleplugin.tasks
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.options.Option
+
+/**
+ * Extension of the JavaExec class to add specific argument options
+ * for the Mendix java command. To start a Mendix application two
+ * arguments are required: app folder and configuration file. These
+ * would normally be passed as the `args` parameter in MxRun. These
+ * parameters are now set explicitly for this plugin. The user is
+ * expected to only set the config file option.
+ *
+ * NOTE: This tasks makes the JavaExec 'args' argument obsolete.
+ */
+abstract class MxRun : JavaExec() {
+
+    @get:InputFile
+    @get:Option(option = "configFile", description = "Configuration file to use")
+    abstract val configFile: RegularFileProperty
+
+    @get:InputDirectory
+    abstract val appFolder: RegularFileProperty
+
+    override fun exec() {
+        args = listOf(
+            appFolder.get().asFile.absolutePath,
+            configFile.get().asFile.absolutePath
+        )
+        super.exec()
+    }
+
+}


### PR DESCRIPTION
Extend JavaExec for mxRun to make configuration of arguments easier as the user mainly needs to to change the config file and not the deployment folder.