### PR TITLE
Force loading of the SQLite driver

### DIFF
--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/mendix/AppVersionHelper.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/mendix/AppVersionHelper.kt
@@ -9,7 +9,18 @@ fun GetAppVersion(mprFile: File): String {
         throw RuntimeException("MPR file can't be found: ${mprFile.name}")
     }
 
-    // Class.forName("org.sqlite.JDBC");
+    //
+    // Caused by: java.sql.SQLException: No suitable driver found for jdbc:sqlite:C:\project\App.mpr
+    //	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:708)
+    //	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:253)
+    //	at mendixlabs.mendixgradleplugin.mendix.AppVersionHelperKt.GetAppVersion(AppVersionHelper.kt:13)
+    // 
+    // Sometimes Gradle throws an error on loading the MPR file that JDBC driver can't be found.
+    // It's unclear what causes this, `gradlew --stop` sometimes resolves the issue, but not always.
+    // Could the gradle daemon be interfering with the classpath? To bypass this, we explicitly
+    // load the SQLite JDBC driver here.
+    //
+    Class.forName("org.sqlite.JDBC");
     DriverManager.getConnection("jdbc:sqlite:${mprFile.absolutePath}").use { con ->
         con.createStatement().use { statement ->
             val rs = statement.executeQuery ("SELECT _ProductVersion FROM _MetaData")


### PR DESCRIPTION
Reading the version of the MPR file is flaky due to cases where the SQLite driver can't be loaded. The cause is unknown but seems to relate to the Gradle daemon lifecycle. This commit prevents the issue by a forced load of the driver class.