### PR TITLE
Improve Java location detection for mxbuild

### DIFF
--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/tasks/Mxbuild.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/tasks/Mxbuild.kt
@@ -138,8 +138,11 @@ abstract class Mxbuild : DefaultTask() {
 
     @Internal
     fun getJavaHome(): String {
-        // to do , better error handling
-        return System.getenv("JAVA_HOME")
+        // Prefer Gradle's javaHome if set, otherwise use the JVM running Gradle.
+        // we'll assume for now this is the same Java version as configured
+        // in the Mendix project.
+        val gradleJavaHome = project.findProperty("org.gradle.java.home") as? String
+        return gradleJavaHome ?: System.getProperty("java.home")
     }
 
     @Internal


### PR DESCRIPTION
For the `mxbuild` step the Java location was retrieved solely from the `JAVA_HOME` environment variable. In case where Java is available on the `PATH` it also forced users to set `JAVA_HOME`. This is resolved by taking the value from Gradle as fallback.