### PR TITLE
Expose tool finder via extension

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -54,3 +54,14 @@ On Windows `installPath` defaults to `C:\Program Files\Mendix`. For other operat
 To construct this folder structure from the CDN artifacts `mxbuild-<version>.targ.z` and `runtime-<version>.tar.gz`
 first unzip the runtime. This gives you a folder named with the version like `<version>\runtime`. Then unzip the
 mxbuild file into this created folder.
+
+
+## Extension functions
+
+The extension exposes the following functions/utilities:
+
+* `toolFinder`: To locate the Mendix runtime and tools the plugin exposes `toolFinder` as utility. 
+   See [ToolFinder](https://github.com/mendixlabs/mendix-gradle-plugin/blob/main/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/ToolFinder.kt#L47) for details.
+   The returned implementation of tool finder searches directories for tools in specified order 
+   and is specific for the operating system in use.
+   

--- a/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/ToolFinder.kt
+++ b/plugin/src/main/kotlin/mendixlabs/mendixgradleplugin/ToolFinder.kt
@@ -44,13 +44,57 @@ enum class Os {
 
 }
 
+/**
+ * ToolFinder is a utility to help detect and location the location
+ * of Mendix tools and runtime.
+ */
 interface ToolFinder {
+    /**
+     * Checks if the Mendix runtime is installed.
+     * @return true if installed, false otherwise
+     */
     fun isRuntimeInstalled(): Boolean
+
+    /**
+     * Gets the location of the Mendix runtime.
+     * @return path to the runtime as a String
+     * @throws RuntimeException if not installed
+     */
     fun getRuntimeLocation(): String
+
+    /**
+     * Checks if the Mendix Modeler is installed.
+     * @return true if installed, false otherwise
+     */
     fun isModelerInstalled(): Boolean
+
+    /**
+     * Gets the location of a specific Mendix tool.
+     * @param tool name of the tool executable
+     * @return path to the tool as a String
+     * @throws RuntimeException if not available
+     */
     fun getToolLocation(tool: String): String
+
+    /**
+     * Gets the location of the 'mx' tool.
+     * @return path to 'mx' as a String
+     * @throws RuntimeException if not available
+     */
     fun getMxLocation(): String
+
+    /**
+     * Gets the location of the 'mxbuild' tool.
+     * @return path to 'mxbuild' as a String
+     * @throws RuntimeException if not available
+     */
     fun getMxbuildLocation(): String
+
+    /**
+     * Gets the location of the 'mxutil' tool.
+     * @return path to 'mxutil' as a String
+     * @throws RuntimeException if not available
+     */
     fun getMxutilLocation(): String
 }
 


### PR DESCRIPTION
The tool finder utility helps to find Mendix tools and runtime and is now exposed via the extension. See documentation for available methods.